### PR TITLE
Update GarageDoor model to allow some "None" values 

### DIFF
--- a/src/genie_partner_sdk/model.py
+++ b/src/genie_partner_sdk/model.py
@@ -22,6 +22,6 @@ class GarageDoor:
         self.door_number: int = data["door_number"]
         self.unique_id: str = f"{self.device_id}-{self.door_number}"
         self.name: str = data["name"]
-        self.status: str = data["status"]
-        self.link_status: str = data["link_status"]
-        self.battery_level: int = data["battery_level"]
+        self.status: str | None = data["status"]
+        self.link_status: str | None = data["link_status"]
+        self.battery_level: int | None = data["battery_level"]


### PR DESCRIPTION
There is currently a bug in the Home Assistant integration for Aladdin Connect detailed here: https://github.com/home-assistant/core/issues/151642

A PR has been submitted to fix the bug within Home Assistant: https://github.com/home-assistant/core/pull/151652

To best support that fix, this PR includes a change to the `GarageDoor` class to allow for `status`, `link_status`, and `battery_level` to be `None`. The `get_door_status` and `get_battery_status` functions already can return `None` so this prevents type issues between the two.