### PR TITLE
Update GarageDoorData to allow None for some values

### DIFF
--- a/src/genie_partner_sdk/model.py
+++ b/src/genie_partner_sdk/model.py
@@ -9,9 +9,9 @@ class GarageDoorData(TypedDict):
     device_id: str
     door_number: int
     name: str
-    status: str
-    link_status: str
-    battery_level: int
+    status: str | None
+    link_status: str | None
+    battery_level: int | None
 
 
 class GarageDoor:


### PR DESCRIPTION
@swcloudgenie Update GarageDoorData to also allow for `None`. This should have been included in the previous PR, but I missed it. This is required to create each GarageDoor object. I have tested these changes with Home Assistant and can verify that no further changes will be needed after pushing to pypi.